### PR TITLE
Turn of build notifications of the fork

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,3 @@ branches:
     - v1.3.x-bugfix
     - add-rubinius-support
 
-notifications:
-  email:
-    - cukes-devs@googlegroups.com
-  irc:
-    - "irc.freenode.org#cucumber"


### PR DESCRIPTION
Great that you help out with Cucumber-Ruby @danascheider. But please turn of the build notifications on your fork, they create noise on the [Cukes Devs mailing list](https://groups.google.com/forum/#!forum/cukes-devs).
